### PR TITLE
replace substituteAll with replaceVars

### DIFF
--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -1,5 +1,4 @@
 { lib
-, substituteAll
 , runCommand
 , writeShellScriptBin
 , buildROSEnv

--- a/packages/ros/workspace-autocomplete-setup/default.nix
+++ b/packages/ros/workspace-autocomplete-setup/default.nix
@@ -1,4 +1,4 @@
-{ substituteAll
+{ replaceVars
 , python3Packages
 }:
 
@@ -6,8 +6,6 @@ let
   inherit (python3Packages)
     argcomplete;
 in
-substituteAll {
-  name = "workspace-autocomplete-setup.sh";
-  src = ./setup.sh;
+replaceVars ./setup.sh {
   inherit argcomplete;
 }


### PR DESCRIPTION
As of latest nixpkgs, `substituteAll` has been removed. This replaces it with the supported `replaceVars`.