### PR TITLE
Add flake usage and extra `buildROSWorkspace` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,24 @@ issues.
 
 ## Setup
 
-1. Set up [lopsided98/nix-ros-overlay], ensuring that [PR #269](https://github.com/lopsided98/nix-ros-overlay/pull/269) is included.
+### Flakes
+
+1. Set up [lopsided98/nix-ros-overlay].
+2. Add this repository as a flake input.
+3. Apply the default overlay after `nix-ros-overlay`: `nix-ros-workspace.overlays.default`
+
+### "Classic" Nix
+
+1. Set up [lopsided98/nix-ros-overlay].
 2. Add the overlay from this repository (`(import /path/to/repository { }).overlay`).
 
 ## Usage
 
 ### API
 
-`buildROSWorkspace` is included in the ROS distro package sets. The following
-examples are designed to be invoked with [`callPackage`](https://nixos.org/guides/nix-pills/callpackage-design-pattern.html), e.g.
-`rosPackages.rolling.callPackage`.
+`buildROSWorkspace` is included in the ROS distro package sets.
+The following examples are designed to be invoked with [`callPackage`](https://nixos.org/guides/nix-pills/13-callpackage-design-pattern.html),
+e.g.  `rosPackages.rolling.callPackage`.
 
 `buildROSWorkspace` takes a derivation name and several sets of packages.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ An opinionated builder for ROS workspaces using [lopsided98/nix-ros-overlay].
 
 ## Quickstart
 
-To open a shell with ROS 2: Humble Hawksbill, `rviz2`, and `turtlesim`:
+To open a shell with ROS 2 "Jazzy Jalisco", `rviz2`, and `turtlesim`:
 
 ```console
 $ nix-shell \
   --extra-substituters 'https://ros.cachix.org' --extra-trusted-public-keys 'ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
   https://github.com/hacker1024/nix-ros-workspace/archive/master.tar.gz -A cli.env \
-  --argstr distro humble \
+  --argstr distro jazzy \
   --argstr rosPackages 'rviz2 turtlesim'
 ```
 
@@ -20,7 +20,7 @@ Or, to build a derivation containing all of the above, use `nix-build` and remov
 $ nix-build \
   --extra-substituters 'https://ros.cachix.org' --extra-trusted-public-keys 'ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
   https://github.com/hacker1024/nix-ros-workspace/archive/master.tar.gz -A cli \
-  --argstr distro humble \
+  --argstr distro jazzy \
   --argstr rosPackages 'rviz2 turtlesim'
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,35 @@ An opinionated builder for ROS workspaces using [lopsided98/nix-ros-overlay].
 
 ## Quickstart
 
-To open a shell with ROS 2 "Jazzy Jalisco", `rviz2`, and `turtlesim`:
+> [!WARNING]
+> To apply any substituter changes and allow binary downloads, you either need to run nix commands with `sudo`, add yourself to [`trusted-users`](https://nix.dev/manual/nix/2.33/command-ref/conf-file.html#conf-trusted-users), or add the cache as a trusted substiter in your Nix config.
+> 
+> The last option is by far the best, as adding yourself to `trusted-users` is a [massive security risk](https://github.com/NixOS/nix/issues/9649#issuecomment-1868001568).
+> However, if you don't apply substituter changes, all software will build locally the first time it's needed.
+
+### Flakes (recommended)
+
+To open a shell with ROS 2 "Jazzy Jalisco", `rviz2`, and `turtlesim` (configured in `flake.nix`):
+
+```console
+nix --extra-experimental-features "nix-command flakes" shell github:hacker1024/nix-ros-workspace#turtlesim
+```
+
+Once in the shell, run this to set up autocomplete:
+
+```console
+eval "$(mk-workspace-shell-setup)"
+```
+
+And to build the derivation:
+
+```console
+nix --extra-experimental-features "nix-command flakes" build github:hacker1024/nix-ros-workspace#turtlesim
+```
+
+### "Classic" Nix
+
+To open a shell with the same configuration as the flake:
 
 ```console
 $ nix-shell \

--- a/README.md
+++ b/README.md
@@ -58,23 +58,33 @@ issues.
 The following examples are designed to be invoked with [`callPackage`](https://nixos.org/guides/nix-pills/13-callpackage-design-pattern.html),
 e.g.  `rosPackages.rolling.callPackage`.
 
-`buildROSWorkspace` takes a derivation name and several sets of packages.
+#### Parameters
 
-- `devPackages` are packages that are under active development. They will be
-available in the release environment (`nix-build`), but in the development
-environment (`nix-shell`), only the build inputs of the packages will be
-available.
+`buildROSWorkspace` takes a derivation name, several sets of packages, and a few parameters to create the workspace:
 
-- `prebuiltPackages` are packages that are not under active development (typically
-third-party packages). They will be available in both the release and
-development environments.
+- `devPackages` (package set): Packages that are under active development.
+  They will be available in the release environment (`nix-build`),
+  but in the development environment (`nix-shell`), only the build inputs of the packages will be available.
+- `prebuiltPackages` (package set): Packages that are not under active development (typically third-party packages).
+  They will be available in both the release and development environments.
+- `prebuiltShellPackages` (package set): Packages that will get added only to the development shell environment.
+  This is useful for build tools like GDB.
+- `interactive` (boolean): Whether or not the workspace should be configured for interactive use.
+  Currently only includes the autocomplete script.
+- `releaseDomainId` (integer): Default ROS domain ID in the release environment.
+  Can be overridden using the `ROS_DOMAIN_ID` environment variable unless `forceReleaseDomainId` is set.
+- `environmentDomainId` (integer): Default ROS domain ID in the development environment.
+  Can be overridden using the `ROS_DOMAIN_ID` environment variable.
+- `forceReleaseDomainId` (boolean): Whether or not to allow the `ROS_DOMAIN_ID` environment variable to change the domain ID in the production environment.
+- `preShellHook` (string): String to insert at the start of the development environment's `shellHook`.
+- `postShellHook` (string): String to insert at the end of the development environment's `shellHook`.
+- `extraRosWrapperArgs` (string): Extra arguments to pass to the `makeWrapper` call for ROS executables.
 
-- `prebuiltShellPackages` are packages that will get added only to the development
-shell environment. This is useful for build tools like GDB.
+Both `releaseDomainId` and `environmentDomainId` will default to the value of the `NRWS_DOMAIN_ID` environment variable at evaluation time [^env-var], or `0` if it is unset.
 
-In order to set a default ROS domain ID, the `manualDomainId` argument can be
-set. This defaults to the value of the `NRWS_DOMAIN_ID` environment variable at
-evaluation time, or `0` if it is unset.
+[^env-var]: However, this requires impure evaluation to take effect.
+
+#### Examples
 
 ```nix
 { buildROSWorkspace

--- a/cli/default.nix
+++ b/cli/default.nix
@@ -1,19 +1,23 @@
 # This function is designed for convenience on the CLI.
 # It is not intended to be used programatically.
-
-{ distro, rosPackages ? [ ], otherPackages ? [ ] }:
-
+{
+  distro,
+  rosPackages ? [ ],
+  otherPackages ? [ ],
+}:
 let
   pkgs = import ./with-overlay.nix { };
   rosPkgs = pkgs.rosPackages.${distro};
 
-  parseList = list:
-    if builtins.isList list
-    then list
-    else builtins.filter builtins.isString (builtins.split "[[:space:]]+" list);
+  parseList =
+    list:
+    if builtins.isList list then
+      list
+    else
+      builtins.filter builtins.isString (builtins.split "[[:space:]]+" list);
 in
 rosPkgs.buildROSWorkspace {
   prebuiltPackages =
-    (pkgs.lib.genAttrs (parseList rosPackages) (name: rosPkgs.${name})) //
-    (pkgs.lib.genAttrs (parseList otherPackages) (name: pkgs.${name}));
+    (pkgs.lib.genAttrs (parseList rosPackages) (name: rosPkgs.${name}))
+    // (pkgs.lib.genAttrs (parseList otherPackages) (name: pkgs.${name}));
 }

--- a/cli/with-overlay.nix
+++ b/cli/with-overlay.nix
@@ -1,8 +1,6 @@
-{ nix-ros-overlay ? builtins.fetchTarball "https://github.com/lopsided98/nix-ros-overlay/archive/master.tar.gz"
-, overlays ? [ ]
-, ...
+{
+  nix-ros-overlay ? builtins.fetchTarball "https://github.com/lopsided98/nix-ros-overlay/archive/master.tar.gz",
+  overlays ? [ ],
+  ...
 }@args:
-
-import nix-ros-overlay (args // {
-  overlays = [ (import ../overlay) ] ++ overlays;
-})
+import nix-ros-overlay (args // { overlays = [ (import ../overlay) ] ++ overlays; })

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
 { ... }@args:
-
 {
   overlay = import ./overlay;
   cli = import ./cli args;

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -24,26 +24,27 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1732499581,
-        "narHash": "sha256-tJezapgYsc3c+o4L6EcvG8TmFKX2qBr8GmLvGbWwfCM=",
+        "lastModified": 1761810010,
+        "narHash": "sha256-o0wJKW603SiOO373BTgeZaF6nDxegMA/cRrzSC2Cscg=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "567652324584bd1339384e5ade6ed0ed53501eed",
+        "rev": "e277df39e3bc6b372a5138c0bcf10198857c55ab",
         "type": "github"
       },
       "original": {
         "owner": "lopsided98",
+        "ref": "master",
         "repo": "nix-ros-overlay",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726243404,
-        "narHash": "sha256-sjiGsMh+1cWXb53Tecsm4skyFNag33GPbVgCdfj3n9I=",
+        "lastModified": 1744849697,
+        "narHash": "sha256-S9hqvanPSeRu6R4cw0OhvH1rJ+4/s9xIban9C4ocM/0=",
         "owner": "lopsided98",
         "repo": "nixpkgs",
-        "rev": "345c263f2f53a3710abe117f28a5cb86d0ba4059",
+        "rev": "6318f538166fef9f5118d8d78b9b43a04bb049e4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,83 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-ros-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1732499581,
+        "narHash": "sha256-tJezapgYsc3c+o4L6EcvG8TmFKX2qBr8GmLvGbWwfCM=",
+        "owner": "lopsided98",
+        "repo": "nix-ros-overlay",
+        "rev": "567652324584bd1339384e5ade6ed0ed53501eed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lopsided98",
+        "repo": "nix-ros-overlay",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726243404,
+        "narHash": "sha256-sjiGsMh+1cWXb53Tecsm4skyFNag33GPbVgCdfj3n9I=",
+        "owner": "lopsided98",
+        "repo": "nixpkgs",
+        "rev": "345c263f2f53a3710abe117f28a5cb86d0ba4059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lopsided98",
+        "ref": "nix-ros",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-ros-overlay": "nix-ros-overlay",
+        "nixpkgs": [
+          "nix-ros-overlay",
+          "nixpkgs"
+        ]
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1761810010,
-        "narHash": "sha256-o0wJKW603SiOO373BTgeZaF6nDxegMA/cRrzSC2Cscg=",
+        "lastModified": 1765653066,
+        "narHash": "sha256-vYxt1MMzcNfznevUyrsxYODxYqzaXODrclgseyKypLo=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "e277df39e3bc6b372a5138c0bcf10198857c55ab",
+        "rev": "a366a7f2a7d66e80862e1c69851e1bd4e99ad583",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         };
       in
       {
-        formatter = pkgs.nixfmt-rfc-style;
+        formatter = pkgs.nixfmt-tree;
       }
     )
     // {

--- a/flake.nix
+++ b/flake.nix
@@ -28,5 +28,10 @@
       {
         formatter = pkgs.nixfmt-rfc-style;
       }
-    );
+    )
+    // {
+      overlays = {
+        default = (import ./overlay);
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Workspace builder for ROS based on lopsided98/nix-ros-overlay";
+
+  inputs = {
+    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay";
+    nixpkgs.follows = "nix-ros-overlay/nixpkgs"; # IMPORTANT!!!
+  };
+
+  outputs =
+    {
+      self,
+      nix-ros-overlay,
+      nixpkgs,
+    }:
+    nix-ros-overlay.inputs.flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            # add the requisite ROS overlay
+            nix-ros-overlay.overlays.default
+            # and import our own workspace
+            (import ./overlay)
+          ];
+        };
+      in
+      {
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,12 @@
   description = "Workspace builder for ROS based on lopsided98/nix-ros-overlay";
 
   inputs = {
-    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay";
+    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay/master";
     nixpkgs.follows = "nix-ros-overlay/nixpkgs"; # IMPORTANT!!!
   };
 
   outputs =
     {
-      self,
       nix-ros-overlay,
       nixpkgs,
     }:

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     {
       nix-ros-overlay,
       nixpkgs,
+      ...
     }:
     nix-ros-overlay.inputs.flake-utils.lib.eachDefaultSystem (
       system:

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -1,9 +1,9 @@
-self: super: {
+final: prev: {
   rosPackages = builtins.mapAttrs (
     rosDistro: rosDistroPackages:
     if rosDistroPackages ? overrideScope then
-      rosDistroPackages.overrideScope (import ./ros-distro-overlay.nix self super)
+      rosDistroPackages.overrideScope (import ./ros-distro-overlay.nix final prev)
     else
       rosDistroPackages
-  ) super.rosPackages;
+  ) prev.rosPackages;
 }

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -1,10 +1,9 @@
-self: super:
-
-{
-  rosPackages = builtins.mapAttrs
-    (rosDistro: rosDistroPackages:
-      if rosDistroPackages ? overrideScope
-      then rosDistroPackages.overrideScope (import ./ros-distro-overlay.nix self super)
-      else rosDistroPackages)
-    super.rosPackages;
+self: super: {
+  rosPackages = builtins.mapAttrs (
+    rosDistro: rosDistroPackages:
+    if rosDistroPackages ? overrideScope then
+      rosDistroPackages.overrideScope (import ./ros-distro-overlay.nix self super)
+    else
+      rosDistroPackages
+  ) super.rosPackages;
 }

--- a/overlay/ros-distro-overlay.nix
+++ b/overlay/ros-distro-overlay.nix
@@ -1,7 +1,4 @@
-self: super:
-rosSelf: rosSuper:
-
-{
+self: super: rosSelf: rosSuper: {
   buildROSWorkspace = rosSelf.callPackage ../packages/ros/build-ros-workspace {
     buildROSEnv = rosSelf.buildEnv;
   };

--- a/overlay/ros-distro-overlay.nix
+++ b/overlay/ros-distro-overlay.nix
@@ -1,6 +1,8 @@
-self: super: rosSelf: rosSuper: {
-  buildROSWorkspace = rosSelf.callPackage ../packages/ros/build-ros-workspace {
-    buildROSEnv = rosSelf.buildEnv;
+final: prev: rosFinal: rosPrev: {
+  buildROSWorkspace = rosFinal.callPackage ../packages/ros/build-ros-workspace {
+    buildROSEnv = rosFinal.buildEnv;
   };
-  workspace-autocomplete-setup = rosSelf.callPackage ../packages/ros/workspace-autocomplete-setup { };
+  workspace-autocomplete-setup =
+    rosFinal.callPackage ../packages/ros/workspace-autocomplete-setup
+      { };
 }

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -28,6 +28,9 @@ in
   releaseDomainId ? domainId,
   environmentDomainId ? domainId,
   forceReleaseDomainId ? false,
+
+  preShellHook ? "",
+  postShellHook ? "",
 }@args:
 
 let
@@ -296,6 +299,7 @@ let
         // andDevPackageEnvs;
 
       shellHook = ''
+        ${preShellHook}
         # The ament setup hooks and propagated build inputs cause path variables
         # to be set in strange orders.
         # For example, it is common to end up with a regular Python executable
@@ -332,6 +336,7 @@ let
             echo >&2 'Set I_WILL_RUN_WORKSPACE_SHELL_SETUP=1 to silence this message.'
           fi
         fi
+        ${postShellHook}
       '';
     };
 in

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -8,11 +8,10 @@
   colcon,
   ros-core,
   workspace-autocomplete-setup,
-
-  manualDomainId ? builtins.getEnv "NRWS_DOMAIN_ID",
 }:
 let
-  domainId = if manualDomainId == "" then 0 else manualDomainId;
+  envDomainId = builtins.getEnv "NRWS_DOMAIN_ID";
+  domainId = if envDomainId == "" then 0 else envDomainId;
 in
 {
   # The name of the workspace.

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -1,13 +1,11 @@
 {
   lib,
-  runCommand,
   writeShellScriptBin,
   buildROSEnv,
   buildROSWorkspace,
   mkShell,
   python,
   colcon,
-  rmw-fastrtps-dynamic-cpp,
   ros-core,
   workspace-autocomplete-setup,
 

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -308,6 +308,9 @@ let
         export CMAKE_PREFIX_PATH="${rosEnv}:$CMAKE_PREFIX_PATH"
         export AMENT_PREFIX_PATH="${rosEnv}:$AMENT_PREFIX_PATH"
         export ROS_PACKAGE_PATH="${rosEnv}/share:$ROS_PACKAGE_PATH"
+        # Create an environment variable pointing to the workspace to allow
+        # easy IDE include path configuration.
+        export ROS_WORKSPACE_ENV_PATH="${rosEnv}"
 
         # Set the domain ID.
         export ROS_DOMAIN_ID=${toString environmentDomainId}

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -53,6 +53,9 @@ let
         wrong = { };
       };
 
+  # Check if a package is a ROS package.
+  isRosPackage = package: package.rosPackage or false;
+
   # Recursively finds required dependency workspacePackages of the given package.
   getWorkspacePackages =
     package:
@@ -89,15 +92,15 @@ let
     // getWorkspacePackages' (standardPackages // prebuiltPackages // devPackages);
 
   # Sort package groups into ROS and other (non-ROS).
-  splitRosDevPackages = partitionAttrs (name: pkg: pkg.rosPackage or false) (devPackages);
+  splitRosDevPackages = partitionAttrs (name: isRosPackage) devPackages;
   rosDevPackages = splitRosDevPackages.right;
   otherDevPackages = splitRosDevPackages.wrong;
 
-  splitRosPrebuiltPackages = partitionAttrs (name: pkg: pkg.rosPackage or false) allPrebuiltPackages;
+  splitRosPrebuiltPackages = partitionAttrs (name: isRosPackage) allPrebuiltPackages;
   rosPrebuiltPackages = splitRosPrebuiltPackages.right;
   otherPrebuiltPackages = splitRosPrebuiltPackages.wrong;
 
-  splitPrebuiltShellPackages = partitionAttrs (name: pkg: pkg.rosPackage or false) (
+  splitPrebuiltShellPackages = partitionAttrs (name: isRosPackage) (
     prebuiltShellPackages // getWorkspacePackages' prebuiltShellPackages
   );
   rosPrebuiltShellPackages = splitPrebuiltShellPackages.right;

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -221,18 +221,25 @@ let
         builtins.attrValues rosDevPackages
       );
 
-      rosEnv = buildROSEnv {
-        paths =
-          builtins.attrValues rosPrebuiltPackages
-          ++ builtins.attrValues rosPrebuiltShellPackages
-          ++ allRosDevDependencies;
-        postBuild = ''
-          rosWrapperArgs+=(--set-default ROS_DOMAIN_ID ${toString environmentDomainId})
-        '';
-      };
+      rosEnv =
+        (buildROSEnv {
+          paths =
+            builtins.attrValues rosPrebuiltPackages
+            ++ builtins.attrValues rosPrebuiltShellPackages
+            ++ allRosDevDependencies;
+          postBuild = ''
+            rosWrapperArgs+=(--set-default ROS_DOMAIN_ID ${toString environmentDomainId})
+          '';
+        }).override
+          (
+            { ... }:
+            {
+              name = "ros-${ros-core.rosDistro}-${name}-shell-env";
+            }
+          );
     in
     mkShell {
-      name = "${workspace.name}-env";
+      name = "ros-${ros-core.rosDistro}-${name}-shell";
 
       packages =
         builtins.attrValues otherPrebuiltPackages

--- a/packages/ros/build-ros-workspace/default.nix
+++ b/packages/ros/build-ros-workspace/default.nix
@@ -31,6 +31,8 @@ in
 
   preShellHook ? "",
   postShellHook ? "",
+
+  extraRosWrapperArgs ? "",
 }@args:
 
 let
@@ -122,9 +124,11 @@ let
     (buildROSEnv {
       paths = builtins.attrValues rosPackages;
       postBuild = ''
+        rosWrapperArgs+=(--prefix GZ_SIM_SYSTEM_PLUGIN_PATH : "$out/lib")
         rosWrapperArgs+=(${
           if forceReleaseDomainId then "--set" else "--set-default"
         } ROS_DOMAIN_ID ${toString releaseDomainId})
+        rosWrapperArgs+=(${extraRosWrapperArgs})
       '';
     }).override
       (
@@ -231,7 +235,9 @@ let
             ++ builtins.attrValues rosPrebuiltShellPackages
             ++ allRosDevDependencies;
           postBuild = ''
+            rosWrapperArgs+=(--prefix GZ_SIM_SYSTEM_PLUGIN_PATH : "$out/lib")
             rosWrapperArgs+=(--set-default ROS_DOMAIN_ID ${toString environmentDomainId})
+            rosWrapperArgs+=(${extraRosWrapperArgs})
           '';
         }).override
           (

--- a/packages/ros/workspace-autocomplete-setup/default.nix
+++ b/packages/ros/workspace-autocomplete-setup/default.nix
@@ -1,10 +1,10 @@
-{ replaceVars
-, python3Packages
+{
+  replaceVars,
+  python3Packages,
 }:
 
 let
-  inherit (python3Packages)
-    argcomplete;
+  inherit (python3Packages) argcomplete;
 in
 replaceVars ./setup.sh {
   inherit argcomplete;


### PR DESCRIPTION
- Added flake support
- Refactored `buildROSWorkspace` a bit and added comments for readability
- Added extra functionality to configure the workspace
- Format using RFC style

Technically this includes breaking changes, since I removed the `manualDomainId` parameter, but that functionality has been replaced with `releaseDomainId` and `environmentDomainId`. I also kept the `NRWS_DOMAIN_ID` default behaviour. Happy to revert if it's an issue.

PS: Hi from the QUTRC rover team!